### PR TITLE
Add "ChromeOS" detection support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,28 @@ The report object has the following keys and value types.
 
 # Coverage
 
-The goal is to correctly identify all browsers included on caniuse.com according to their [browser usage table][3]. As of January 18, 2017, their browser usage table accounts for 98.19% of global usage based on data from [StatCounter GlobalStats][4].
+The goal is to correctly identify all browsers included on caniuse.com according to their [browser usage table][3]. As of February 11, 2017, their browser usage table accounts for 98.32% of global usage based on data from [StatCounter GlobalStats][4].
 
-Coverage, as of January 18, 2017, matches at __98.19%__
+If test coverage for operating systems is to meet the same level of coverage as the browsers, it would require __98.32%__ of the [StatsCounter GlobalStats for worldwide market share][8]. Hence the following operating systems should be properly detected:
+
+| OS | % |
+|----|---:|
+|Android|37.15|
+|Win7|18.12
+|iOS|13.16
+|Win10|12.53
+|OS X|5.06
+|Win8.1|3.68
+|Unknown|2.63
+|WinXP|2.18
+|Win8|1.15
+|Linux|0.78
+|Nokia Unknown|0.75
+|Windows Phone|0.56
+|Series 40|0.46
+|WinVista|0.46
+
+Coverage, as of February 11, 2017, matches at __98.32%__
 
 # Benchmarks
 
@@ -203,3 +222,4 @@ browser-report is available under the [MIT License][6].
   [5]: http://stackoverflow.com/questions/9514179/how-to-find-the-operating-system-version-using-javascript
   [6]: https://github.com/keithws/browser-report/blob/master/LICENSE
   [7]: https://github.com/faisalman/ua-parser-js
+  [8]: http://gs.statcounter.com/os-market-share

--- a/index.js
+++ b/index.js
@@ -329,6 +329,9 @@
             report.os.name = "BlackBerryOS";
         }
 
+        if (userAgent.indexOf("CrOS") >= 0) {
+            report.os.name = "Chrome OS";
+        }
 
         // extract operating system version from user agent
         match = null;

--- a/index.js
+++ b/index.js
@@ -413,6 +413,9 @@
         case "BlackBerry Tablet OS":
             match = userAgent.match(/RIM Tablet OS ((\d+\.)+\d+)/);
             break;
+		case "Chrome OS":
+			report.os.version = report.browser.version;
+			break;
         default:
             // no good default behavior
             report.os.version = null;

--- a/index.js
+++ b/index.js
@@ -413,9 +413,9 @@
         case "BlackBerry Tablet OS":
             match = userAgent.match(/RIM Tablet OS ((\d+\.)+\d+)/);
             break;
-		case "Chrome OS":
-			report.os.version = report.browser.version;
-			break;
+	case "Chrome OS":
+            report.os.version = report.browser.version;
+            break;
         default:
             // no good default behavior
             report.os.version = null;

--- a/test/data/known-user-agent-results.js
+++ b/test/data/known-user-agent-results.js
@@ -211,6 +211,34 @@ var expectedResults = [
         }
     },
     {
+        "device": "Chrome 55 — Chromebook",
+        "userAgent": "Mozilla/5.0 (X11; CrOS x86_64 8872.76.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.105 Safari/537.36",
+        "expectedReport": {
+            "browser": {
+                "name": "Chrome",
+                "version": "55.0.2883.105"
+            },
+            "os": {
+                "name": "Chrome OS",
+                "version": "55.0.2883.105"
+            }
+        }
+    },
+    {
+        "device": "Chrome 30 — Chromebook",
+        "userAgent": "Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.38 Safari/537.36",
+        "expectedReport": {
+            "browser": {
+                "name": "Chrome",
+                "version": "30.0.1599.38"
+            },
+            "os": {
+                "name": "Chrome OS",
+                "version": "30.0.1599.38"
+            }
+        }
+    },
+    {
         "device": "Safari",
         "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_0) AppleWebKit/601.4.4 (KHTML, like Gecko) Version/9.0.3 Safari/601.4.4",
         "expectedReport": {


### PR DESCRIPTION
This will detect ChromeOS on Chromebooks. Here's a user agent that's been captured on a ChromeOS: 

**Mozilla/5.0 (X11; CrOS x86_64 8872.76.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.105 Safari/537.36**

However, I'm not sure how to detect its version since I didn't find a list of possible user agents on Chromebooks.